### PR TITLE
Fix vertical spacing in iOS catalog

### DIFF
--- a/ios_widget_catalog_compare/ios/Runner/OverlaySwiftUIView.swift
+++ b/ios_widget_catalog_compare/ios/Runner/OverlaySwiftUIView.swift
@@ -37,6 +37,6 @@ struct OverlaySwiftUIView: View {
   }
   
   var body: some View {
-    controlDictionary[controller.controlKey]?.1 ?? AnyView(Text("Nothing Selected"))
-  }
+    (controlDictionary[controller.controlKey]?.1 ?? AnyView(Text("Nothing Selected")))
+      .frame(maxWidth: .infinity, maxHeight: .infinity).edgesIgnoringSafeArea(.all)  }
 }


### PR DESCRIPTION
A little testing indicated that the SwiftUI view was being throttled by the safe area layout guides, making it appear as if the flutter's center was not UIKit's center. All is good now.

Before:
<img src="https://user-images.githubusercontent.com/11810973/95515970-5a8cd480-0973-11eb-84d8-f3ddf68fd9d5.png" width=300>

After (both components lying on top of each other): 
<img src="https://user-images.githubusercontent.com/11810973/95516147-a5a6e780-0973-11eb-93ac-feb7d43e8ac2.png" width=300>

