### PR TITLE
Add `CupertinoSliverNavigationBar`

### DIFF
--- a/ios_widget_catalog_compare/ios/Runner/OverlaySwiftUIView.swift
+++ b/ios_widget_catalog_compare/ios/Runner/OverlaySwiftUIView.swift
@@ -99,6 +99,15 @@ struct OverlaySwiftUIView: View {
            ProgressView()
          )
         ),
+      "CupertinoSliverNavigationBar":
+        ("Cupertino Sliver Navigation Bar",
+         AnyView(
+           NavigationView {
+            List {}
+            .navigationTitle("Title")
+           }
+         )
+        ),
     ]
   }
   

--- a/ios_widget_catalog_compare/lib/main.dart
+++ b/ios_widget_catalog_compare/lib/main.dart
@@ -287,6 +287,19 @@ class _FlutterDemoState extends State<FlutterDemo> {
 
       case "CupertinoActivityIndicator":
         return CupertinoActivityIndicator();
+
+      case "CupertinoSliverNavigationBar":
+        return CustomScrollView(
+          slivers: [
+            CupertinoSliverNavigationBar(
+              largeTitle: Text("Title"),
+              backgroundColor: CupertinoColors.white,
+              stretch: true,
+              border: null,
+            ),
+          ],
+        );
+
       default:
         break;
     }


### PR DESCRIPTION
This PR adds `CupertinoSliverNavigationBar` for https://github.com/flutter/flutter/pull/110127

<img src="https://user-images.githubusercontent.com/57679865/192137769-f23ec4d4-8c5a-4b6d-9db8-de5f54a5ca55.gif" width="50%"/>
