### PR TITLE
Fix drift in scroll_overlay Android item alignment; small updates

### DIFF
--- a/scroll_overlay/README.md
+++ b/scroll_overlay/README.md
@@ -1,3 +1,7 @@
 # Scroll Overlay
 
-Overlays a native scroll view over the Flutter view. The scroll view displays items of a random color and opacity. The scroll view forwards all touch events it receives to the underlying Flutter view. This way, the scroll behavior of Flutter and native controls can be compared.
+Overlays a native scroll view over the Flutter view.
+The scroll view displays items of a random color and opacity.
+The scroll view forwards all touch events it receives to the
+underlying Flutter view.  This way, the scroll behavior of
+Flutter and native controls can be compared.

--- a/scroll_overlay/android/app/src/main/java/io/flutter/scroll_overlay/ScrollOverlayActivity.java
+++ b/scroll_overlay/android/app/src/main/java/io/flutter/scroll_overlay/ScrollOverlayActivity.java
@@ -204,11 +204,23 @@ public class ScrollOverlayActivity extends Activity {
              */
             static final int baseItemExtent = 40;
 
+            // Our desired height is in logical pixels, aka dp, but we have to set the
+            // height in the layout as an integer in physical pixels.  If we just
+            // multiply and round, the rounding errors compared to Flutter will add up,
+            // and can get us noticeably out of alignment within a screenful.  So we
+            // compute the exact total offsets in dp and apply the lossy unit conversion
+            // directly to those.
+            private int offsetToTop(int position) {
+                // This is the sum baseItemExtent + (baseItemExtent + 1) + (baseItemExtent + 2) + ….
+                int topInDp = position * baseItemExtent + position * (position - 1) / 2;
+                return (int) TypedValue
+                        .applyDimension(TypedValue.COMPLEX_UNIT_DIP, topInDp, getResources().getDisplayMetrics());
+            }
+
             void bind(int position) {
                 int color = OVERLAY_COLORS[position % OVERLAY_COLORS.length];
                 itemView.setBackground(new ColorDrawable(color));
-                final int height = (int) TypedValue
-                        .applyDimension(TypedValue.COMPLEX_UNIT_DIP, baseItemExtent + position, getResources().getDisplayMetrics());
+                final int height = offsetToTop(position + 1) - offsetToTop(position);
                 itemView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height));
                 TextView textView = itemView.findViewById(R.id.text_view);
                 textView.setText("Android " + position);

--- a/scroll_overlay/lib/main.dart
+++ b/scroll_overlay/lib/main.dart
@@ -22,7 +22,7 @@ void main() {
 }
 
 class FlutterDemo extends StatefulWidget {
-  const FlutterDemo({Key? key}) : super(key: key);
+  const FlutterDemo({super.key});
 
   @override
   _FlutterDemoState createState() => _FlutterDemoState();

--- a/scroll_overlay/pubspec.lock
+++ b/scroll_overlay/pubspec.lock
@@ -5,53 +5,59 @@ packages:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/scroll_overlay/pubspec.lock
+++ b/scroll_overlay/pubspec.lock
@@ -60,4 +60,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"

--- a/scroll_overlay/pubspec.yaml
+++ b/scroll_overlay/pubspec.yaml
@@ -2,7 +2,7 @@ name: scroll_overlay
 description: A Flutter app that overlays a native scroll view over the Flutter view.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Part of my work on flutter/flutter#119875.

The heights on the Android side were systematically up to one physical pixel less than on the Flutter side, due to rounding.  This made the items conspicuously out of alignment by the lower part of the first screen, even before any scrolling, making it impossible to tell whether a given scroll physics matched exactly or had a small discrepancy.

Fix by using a tiny bit more math in the calculation, so that the rounding error doesn't accumulate.

Screenshots:

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/28173/217066058-59f9d2e5-5124-41db-b65e-02d0948fb221.png) | ![after](https://user-images.githubusercontent.com/28173/217066076-3f85d66f-0874-4b78-b483-9ab55dd5baca.png) |

Also make a few small updates and other cleanups, in separate commits for ease of review. In particular, update pubspec.lock so that running the app with a current Flutter doesn't dirty the tree.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
