### PR TITLE
Add scroll-physics logging in scroll_overlay

### DIFF
--- a/scroll_overlay/lib/main.dart
+++ b/scroll_overlay/lib/main.dart
@@ -10,11 +10,17 @@ import 'package:flutter/services.dart';
 const EventChannel _platformVelocityEventChannel = EventChannel('scroll_overlay.flutter.io/velocity');
 
 void main() {
-  runApp(DemoApp());
+  runApp(DemoApp(
+    // EDIT HERE if you want to experiment with a custom [ScrollPhysics].
+    physics: null,
+  ));
 }
 
 class DemoApp extends StatelessWidget {
-  const DemoApp({super.key});
+  const DemoApp({super.key, this.physics});
+
+  /// The scroll physics to apply on top of the default.
+  final ScrollPhysics? physics;
 
   @override
   Widget build(BuildContext context) {
@@ -23,13 +29,16 @@ class DemoApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const FlutterDemo(),
+      home: FlutterDemo(physics: physics),
     );
   }
 }
 
 class FlutterDemo extends StatefulWidget {
-  const FlutterDemo({super.key});
+  const FlutterDemo({super.key, this.physics});
+
+  /// The scroll physics to apply on top of the default.
+  final ScrollPhysics? physics;
 
   @override
   _FlutterDemoState createState() => _FlutterDemoState();
@@ -87,15 +96,9 @@ class _FlutterDemoState extends State<FlutterDemo> {
     super.dispose();
   }
 
-  /// The scroll physics to apply on top of the default.
-  ///
-  /// Edit this to return any custom [ScrollPhysics] you want to use this test
-  /// app to experiment with.
-  ScrollPhysics? get customScrollPhysics => null;
-
   ScrollPhysics getScrollPhysics(BuildContext context) {
     final parent = ScrollConfiguration.of(context).getScrollPhysics(context);
-    final custom = customScrollPhysics;
+    final custom = widget.physics;
     final physics = custom != null ? custom.applyTo(parent) : parent;
     return DebugScrollPhysics().applyTo(physics);
   }

--- a/scroll_overlay/lib/main.dart
+++ b/scroll_overlay/lib/main.dart
@@ -87,6 +87,18 @@ class _FlutterDemoState extends State<FlutterDemo> {
     super.dispose();
   }
 
+  /// The scroll physics to apply on top of the default.
+  ///
+  /// Edit this to return any custom [ScrollPhysics] you want to use this test
+  /// app to experiment with.
+  ScrollPhysics? get customScrollPhysics => null;
+
+  ScrollPhysics getScrollPhysics(BuildContext context) {
+    final parent = ScrollConfiguration.of(context).getScrollPhysics(context);
+    final custom = customScrollPhysics;
+    return custom != null ? custom.applyTo(parent) : parent;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -95,6 +107,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
           ListView.builder(
             controller: controller,
             itemCount: 1000,
+            physics: getScrollPhysics(context),
             itemBuilder: (BuildContext context, int index) {
               return Container(
                 height: (baseItemExtent + index).toDouble(),

--- a/scroll_overlay/lib/main.dart
+++ b/scroll_overlay/lib/main.dart
@@ -96,7 +96,8 @@ class _FlutterDemoState extends State<FlutterDemo> {
   ScrollPhysics getScrollPhysics(BuildContext context) {
     final parent = ScrollConfiguration.of(context).getScrollPhysics(context);
     final custom = customScrollPhysics;
-    return custom != null ? custom.applyTo(parent) : parent;
+    final physics = custom != null ? custom.applyTo(parent) : parent;
+    return DebugScrollPhysics().applyTo(physics);
   }
 
   @override
@@ -149,5 +150,31 @@ class _FlutterDemoState extends State<FlutterDemo> {
         ],
       ),
     );
+  }
+}
+
+const bool debugPrintCreateBallisticSimulation = true;
+
+/// A [ScrollPhysics] that just forwards to its [parent], plus debug logging.
+///
+/// This prints debug log messages on key method calls that are expected to be
+/// of interest for anyone investigating scrolling behavior.
+class DebugScrollPhysics extends ScrollPhysics {
+  const DebugScrollPhysics({super.parent});
+
+  @override
+  DebugScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return DebugScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    if (debugPrintCreateBallisticSimulation) {
+      debugPrint(
+          "createBallisticSimulation: velocity ${velocity.toStringAsFixed(1)}" +
+              ", offset ${position.pixels.toStringAsFixed(1)}" +
+              ", range ${position.minScrollExtent.toStringAsFixed(1)}..${position.maxScrollExtent.toStringAsFixed(1)}");
+    }
+    return super.createBallisticSimulation(position, velocity);
   }
 }

--- a/scroll_overlay/test/smoke_test.dart
+++ b/scroll_overlay/test/smoke_test.dart
@@ -11,6 +11,30 @@ void main() {
     await tester.pumpAndSettle();
     expect(flutterScrollIndex(), greaterThanOrEqualTo(70));
   });
+
+  testWidgets('FlutterDemo.physics - use flingless physics', (WidgetTester tester) async {
+    await tester.pumpWidget(DemoApp(physics: FlinglessScrollPhysics()));
+    await tester.pumpAndSettle();
+    await tester.fling(find.text('Flutter 5'), const Offset(0, -500), 8000);
+    await tester.pump();
+    final startIndex = flutterScrollIndex();
+    await tester.pumpAndSettle();
+    expect(flutterScrollIndex(), startIndex);
+  });
+}
+
+class FlinglessScrollPhysics extends ScrollPhysics {
+  const FlinglessScrollPhysics({super.parent});
+
+  @override
+  FlinglessScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return FlinglessScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    return null;
+  }
 }
 
 int flutterScrollIndex() {


### PR DESCRIPTION
This is the last part of the further enhancements after #13 that I've been using for my investigations the past couple of weeks. It consists of two related commits:


#### [scroll_overlay] Add a place to customize the scroll physics

This has been very convenient for experimenting with different
scroll physics in my recent investigations, providing a way to
do so without creating rebase conflicts with other changes to
this `ListView.builder` call.

This is especially useful in combination with the next commit,
adding a piece of debug logging.



#### [scroll_overlay] Add debug print on createBallisticSimulation

This has been extremely convenient in my recent scrolling
investigations.

Because the ScrollPhysics protocol is a bit subtle to hook into
correctly, and requires some boilerplate, inserting debug logging
for it is a bit more complicated than just writing down a
`debugPrint` call of one's choice.  So it benefits from having
this permanent infrastructure in the app.

---

The second commit leaves the debug logging it adds enabled by default. That's not what one would do in the framework or in a normal app; but I think it makes sense here, given that this is a test app and the logging is right at the core of what the app is made to test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
