### PR TITLE
[scroll_overlay] Fix merge in tests

### DIFF
--- a/scroll_overlay/test/smoke_test.dart
+++ b/scroll_overlay/test/smoke_test.dart
@@ -12,6 +12,16 @@ void main() {
     expect(flutterScrollIndex(), greaterThanOrEqualTo(70));
   });
 
+  testWidgets('VelocityOverlay - handles diverse values without error', (WidgetTester tester) async {
+    Future<void> checkWidget(Widget widget) async {
+      await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: widget));
+      await tester.pumpAndSettle();
+    }
+    await checkWidget(VelocityOverlay(flutterVelocity: 0, platformVelocity: 0));
+    await checkWidget(VelocityOverlay(flutterVelocity: 8000, platformVelocity: 0));
+    await checkWidget(VelocityOverlay(flutterVelocity: 0, platformVelocity: 10000));
+  });
+
   testWidgets('FlutterDemo.physics - use flingless physics', (WidgetTester tester) async {
     await tester.pumpWidget(DemoApp(physics: FlinglessScrollPhysics()));
     await tester.pumpAndSettle();
@@ -35,16 +45,6 @@ class FlinglessScrollPhysics extends ScrollPhysics {
   Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
     return null;
   }
-  
-  testWidgets('VelocityOverlay - handles diverse values without error', (WidgetTester tester) async {
-    Future<void> checkWidget(Widget widget) async {
-      await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: widget));
-      await tester.pumpAndSettle();
-    }
-    await checkWidget(VelocityOverlay(flutterVelocity: 0, platformVelocity: 0));
-    await checkWidget(VelocityOverlay(flutterVelocity: 8000, platformVelocity: 0));
-    await checkWidget(VelocityOverlay(flutterVelocity: 0, platformVelocity: 10000));
-  });
 }
 
 int flutterScrollIndex() {


### PR DESCRIPTION
The merge-conflict resolution in #16 caused a test file to not parse. Flip the order so that the test parses and runs correctly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
