### PR TITLE
Replace deprecated strong-mode options

### DIFF
--- a/scroll_overlay/analysis_option.yaml
+++ b/scroll_overlay/analysis_option.yaml
@@ -2,8 +2,9 @@
 #
 # Copied over from flutter/flutter repo.
 analyzer:
-  strong-mode:
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-raw-types: true
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning


### PR DESCRIPTION
Updates to match the new [analysis language options](https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks) also used in [`flutter/flutter`](https://github.com/flutter/flutter/blob/master/analysis_options.yaml).

I'm trying to remove or replace as many uses as possible before the options are fully removed.

Issue reference: https://github.com/dart-lang/sdk/issues/50679