### PR TITLE
Fix class_used_as_mixin error

### DIFF
--- a/transition_overlay/lib/transition_controller_nav_bar.dart
+++ b/transition_overlay/lib/transition_controller_nav_bar.dart
@@ -5,7 +5,7 @@ import 'package:transition_overlay/time_dilation_provider.dart';
 import 'package:transition_overlay/transition_data_provider.dart';
 
 class TransitionControllerNavBar extends StatefulWidget
-    with ObstructingPreferredSizeWidget {
+    implements ObstructingPreferredSizeWidget {
   const TransitionControllerNavBar(
       {super.key, this.secondPageKey, this.isForSecondPage = false});
 


### PR DESCRIPTION
Dart 3 added an error for a [class being used as a mixin](https://dart.dev/tools/diagnostic-messages?utm_source=dartdev&utm_medium=redir&utm_id=diagcode&utm_content=class_used_as_mixin#class_used_as_mixin), which this fixes by using 'implements' instead of 'with'.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
