### PR TITLE
Migrate ios_widget_catalog_compare app to Flutter 3 with null safety

### DIFF
--- a/ios_widget_catalog_compare/lib/main.dart
+++ b/ios_widget_catalog_compare/lib/main.dart
@@ -18,7 +18,7 @@ void main() {
 }
 
 class FlutterDemo extends StatefulWidget {
-  FlutterDemo({Key key}) : super(key: key);
+  FlutterDemo({super.key});
 
   @override
   _FlutterDemoState createState() => _FlutterDemoState();
@@ -26,7 +26,7 @@ class FlutterDemo extends StatefulWidget {
 
 class _FlutterDemoState extends State<FlutterDemo> {
   String controlName = 'Null';
-  TextEditingController textController;
+  late TextEditingController textController;
   bool toggleValue = false;
   final _formKey = GlobalKey<FormState>();
 
@@ -53,7 +53,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
     );
   }
 
-  Widget widgetPicker(BuildContext context) {
+  Widget? widgetPicker(BuildContext context) {
     switch (controlName) {
       case 'CupertinoButton':
         return CupertinoButton(
@@ -108,7 +108,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       prefix: Text('Enter text'),
                       placeholder: "Enter text",
                       validator: (value) {
-                        if (value.isEmpty) {
+                        if (value?.isEmpty ?? false) {
                           return 'Please enter a value';
                         }
                         return null;
@@ -118,7 +118,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       prefix: Text('Enter text'),
                       placeholder: "Enter text",
                       validator: (value) {
-                        if (value.isEmpty) {
+                        if (value?.isEmpty ?? false) {
                           return 'Please enter a value';
                         }
                         return null;
@@ -133,7 +133,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       prefix: Text('Enter text'),
                       placeholder: "Enter text",
                       validator: (value) {
-                        if (value.isEmpty) {
+                        if (value?.isEmpty ?? false) {
                           return 'Please enter a value';
                         }
                         return null;
@@ -143,7 +143,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       prefix: Text('Enter text'),
                       placeholder: "Enter text",
                       validator: (value) {
-                        if (value.isEmpty) {
+                        if (value?.isEmpty ?? false) {
                           return 'Please enter a value';
                         }
                         return null;
@@ -167,7 +167,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       vertical: 16.0, horizontal: 16.0),
                   child: CupertinoButton(
                     onPressed: () {
-                      if (_formKey.currentState.validate()) {
+                      if (_formKey.currentState?.validate() ?? false) {
                         showCupertinoDialog(
                           context: context,
                           builder: (context) => CupertinoAlertDialog(
@@ -204,7 +204,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       prefix: Text('Enter text'),
                       placeholder: "Enter text",
                       validator: (value) {
-                        if (value.isEmpty) {
+                        if (value?.isEmpty ?? false) {
                           return 'Please enter a value';
                         }
                         return null;
@@ -214,7 +214,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       prefix: Text('Enter text'),
                       placeholder: "Enter text",
                       validator: (value) {
-                        if (value.isEmpty) {
+                        if (value?.isEmpty ?? false) {
                           return 'Please enter a value';
                         }
                         return null;
@@ -229,7 +229,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       prefix: Text('Enter text'),
                       placeholder: "Enter text",
                       validator: (value) {
-                        if (value.isEmpty) {
+                        if (value?.isEmpty ?? false) {
                           return 'Please enter a value';
                         }
                         return null;
@@ -239,7 +239,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       prefix: Text('Enter text'),
                       placeholder: "Enter text",
                       validator: (value) {
-                        if (value.isEmpty) {
+                        if (value?.isEmpty ?? false) {
                           return 'Please enter a value';
                         }
                         return null;
@@ -263,7 +263,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
                       vertical: 16.0, horizontal: 16.0),
                   child: CupertinoButton(
                     onPressed: () {
-                      if (_formKey.currentState.validate()) {
+                      if (_formKey.currentState?.validate() ?? false) {
                         showCupertinoDialog(
                           context: context,
                           builder: (context) => CupertinoAlertDialog(

--- a/ios_widget_catalog_compare/pubspec.yaml
+++ b/ios_widget_catalog_compare/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
